### PR TITLE
Fixed a playground environment bug

### DIFF
--- a/src/Playground.jl
+++ b/src/Playground.jl
@@ -55,6 +55,7 @@ function main(cmdargs, configargs...)
 
     config = Config(configargs...)
 
+    debug(logger, "Arguments: $args")
     if cmd == "install"
         install_cmd = args["%COMMAND%"]
         args = args[install_cmd]

--- a/src/config.jl
+++ b/src/config.jl
@@ -61,9 +61,14 @@ end
 
 configpath() = join(home(), ".playground")
 
-envpath(config::Config) = abs(join(cwd(), config.default_playground_path))
+function envpath(config::Config)
+    p = abs(join(cwd(), config.default_playground_path))
+    debug(logger, "Using `default_playground_path`: $p")
+    return p
+end
+
 envpath(config::Config, name::AbstractString) = abs(join(config.share, name))
-envpath(config::Config, path::AbstractPath) = isempty(path) ? envpath(config) : abs(path)
+envpath(config::Config, path::AbstractPath) = abs(path)
 
 function envname(config::Config, path::AbstractPath)
     root_path = abs(path)

--- a/src/create.jl
+++ b/src/create.jl
@@ -17,6 +17,7 @@ create(; kwargs...) = create(Environment(); kwargs...)
 create(config::Config, args...; kwargs...) = create(Environment(config, args...); kwargs...)
 
 function create(env::Environment; kwargs...)
+    debug(logger, "Environment Config: $(env.config)")
     init(env)
     opts = Dict(kwargs)
 

--- a/src/env.jl
+++ b/src/env.jl
@@ -32,7 +32,16 @@ function Environment(config::Config, dir::AbstractPath)
 end
 
 function Environment(config::Config, dir::AbstractPath, name::String)
-    Environment(config, name, envpath(config, dir))
+    p = if isempty(dir) && isempty(name)
+        envpath(config)
+    elseif isempty(dir) && !isempty(name)
+        envpath(config, name)
+    else
+        envpath(config, dir)
+    end
+    
+    debug(logger, "Environment: Name=$name, Path=$p")
+    return Environment(config, name, p)
 end
 
 function init(env::Environment)


### PR DESCRIPTION
Closes #61, #60 and #64 I think? 

The issue was that the default behaviour when a playground path wasn't provided was to create the default_playground_path (e.g., `.playground`) in the current directory.