### PR TITLE
Set prompt for zsh

### DIFF
--- a/src/activate.jl
+++ b/src/activate.jl
@@ -6,7 +6,7 @@
 Modifies the current environment to operate within a specific playground environment.
 When `shell=true` a new shell environment will be created.
 However, when `shell=false` the existing julia REPL will be modifed and
-`deactive(env::Enviornmentt)` must be called to restore the REPL state.
+`deactivate()` must be called to restore the REPL state.
 """
 activate(; shell=true) = activate(Environment(); shell=shell)
 

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -1,6 +1,12 @@
 const DECLARATIVE_PACKAGES_DIR = Pkg.dir("DeclarativePackages")
 const REPL_PROMPT = "playground>"
-const SHELL_PROMPT = is_windows() ? "playground>" : "\\e[0;35m\\u@\\h:\\W (playground)> \\e[m"
+const SHELL_PROMPT = if is_windows()
+    "playground>"
+elseif contains(get(ENV, "SHELL", ""), "zsh")
+    "%F{5}%n@%m:%~ (playground)> %f"
+else
+    "\\e[0;35m\\u@\\h:\\W (playground)> \\e[m"
+end
 const NIGHTLY = v"0.7-"
 const JULIA_BIN_MODE = Mode(user=(READ+WRITE+EXEC), group=(READ+EXEC), other=(READ+EXEC))
 const DEFAULT_CONFIG = """


### PR DESCRIPTION
Closes #59 

This got more complicated than I expected it to, but it works. zsh is pretty weird, mostly because I don't think there's any equivalent to `--rc-file`, so you have to mess around with `$ZDOTDIR` to change the startup file.