### PR TITLE
Removed test dependencies outside of `Pkg.build`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
     packages:
       - gcc-5
       - zsh
-      # - ksh
+      - ksh
       - fish
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
     packages:
       - gcc-5
       - zsh
-      - ksh
+      # - ksh
       - fish
 notifications:
   email: false

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -54,7 +54,7 @@ copy(join(deps_dir, "..", "README.md"), join(build_dir, "README.md"); exist_ok=t
 install = haskey(ENV, "PLAYGROUND_INSTALL") ? parse(ENV["PLAYGROUND_INSTALL"]) : false
 
 # Store our install paths
-install_dir = Playground.configpath()
+install_dir = join(home(), ".playground")
 config_installed = join(install_dir, "config.yml")
 require_installed = join(install_dir, "REQUIRE")
 playground_installed = join(install_dir, "bin", p"playground")

--- a/src/config.jl
+++ b/src/config.jl
@@ -1,7 +1,7 @@
 import YAML: load
 
 """
-    Config(; file=p"~/.playground/config.yml", root=p"~/.playground")
+    Config(p"~/.playground/config.yml", root=p"~/.playground")
 
 Stores various default playground environment settings including paths for
 storing shared binaries and environments.
@@ -49,8 +49,17 @@ function Config(config::AbstractString, root::AbstractPath)
     return Config(config_dict)
 end
 
-function Config{P<:AbstractPath}(; file::P=join(configpath(), "config.yml"), root::P=configpath())
+function Config{P<:AbstractPath}(file::P, root::P=configpath())
     Config(read(file), root)
+end
+
+function Config()
+    config_file = join(configpath(), "config.yml")
+    if exists(config_file)
+        return Config(config_file)
+    else
+        return Config(Playground.DEFAULT_CONFIG, configpath())
+    end
 end
 
 function init(config::Config)
@@ -59,7 +68,11 @@ function init(config::Config)
     end
 end
 
-configpath() = join(home(), ".playground")
+function configpath()
+    default_path = join(home(), ".playground")
+    alt_path = join(parent(parent(Path(@__FILE__))), p"deps", p"usr", p".playground")
+    exists(default_path) ? default_path : alt_path
+end
 
 function envpath(config::Config)
     p = abs(join(cwd(), config.default_playground_path))

--- a/test/shell.jl
+++ b/test/shell.jl
@@ -10,9 +10,7 @@ end
 
 @testset "shell" begin
     @testset "$SH" for SH in ("bash", "zsh", "ksh", "fish")
-        rc = spawn(`which $SH`).exitcode
-
-        if success(spawn(`which $SH`))
+        if success(`which $SH`)
             path = readstring(`which $SH`)
 
             withenv("SHELL" => path) do
@@ -33,9 +31,8 @@ end
         Mocking.apply(patch) do
             withenv(env) do
                 name = split(lowercase(string(SH.name)), '.')[end]
-                rc = spawn(`which $name`).exitcode
 
-                if success(spawn(`which $SH`))
+                if success(`which $name`)
                     sh = SH()
                     resp = strip(run(sh, env))
                     @test resp == "Hello World!"

--- a/test/shell.jl
+++ b/test/shell.jl
@@ -32,7 +32,7 @@ end
 
         Mocking.apply(patch) do
             withenv(env) do
-                name = lowercase(string(SH.name))
+                name = split(lowercase(string(SH.name)), '.')[end]
                 rc = spawn(`which $name`).exitcode
 
                 if success(spawn(`which $SH`))


### PR DESCRIPTION
- Not setting `PLAYGROUND_INSTALL` before `Pkg.build` would cause tests to fail on a clean environment.
- Tests shouldn't depend on having all possible shells installed.